### PR TITLE
Replace parallel accessory arrays with ecosystem inventory lookup by ID

### DIFF
--- a/client/src/components/AdminView.tsx
+++ b/client/src/components/AdminView.tsx
@@ -578,10 +578,19 @@ export const AdminView = () => {
                               : "Not set"}
                       </div>
                     </div>
-                    {gameState.unlockType === "accessory" && gameState.accessoryNames ? (
+                    {gameState.unlockType === "accessory" &&
+                    gameState.accessoryIds?.length &&
+                    gameState.ecosystemAccessories?.length ? (
                       <div className="col-span-2 bg-surface p-2.5 rounded-lg">
                         <div className="text-xs text-ink-soft">Accessories</div>
-                        <div className="text-sm font-semibold">{gameState.accessoryNames.join(", ")}</div>
+                        <div className="text-sm font-semibold">
+                          {gameState.accessoryIds
+                            .map((id) => {
+                              const acc = gameState.ecosystemAccessories!.find((a) => a.id === id);
+                              return acc?.name || "Unknown";
+                            })
+                            .join(", ")}
+                        </div>
                       </div>
                     ) : null}
                   </div>

--- a/client/src/components/UnlockView.tsx
+++ b/client/src/components/UnlockView.tsx
@@ -67,8 +67,15 @@ export const UnlockView = () => {
   const unlockType = gameState?.unlockType || "emote";
   const itemId = gameState?.itemId || gameState?.emoteId;
   const accessoryIds = gameState?.accessoryIds;
-  const accessoryNames = gameState?.accessoryNames;
-  const accessoryPreviewUrls = gameState?.accessoryPreviewUrls;
+  const ecosystemAccessories = gameState?.ecosystemAccessories;
+
+  // Resolve selected accessories by matching IDs against ecosystem items
+  const selectedAccessories = useMemo(() => {
+    if (!accessoryIds?.length || !ecosystemAccessories?.length) return [];
+    return accessoryIds
+      .map((id) => ecosystemAccessories.find((item) => item.id === id))
+      .filter(Boolean) as NonNullable<typeof ecosystemAccessories>;
+  }, [accessoryIds, ecosystemAccessories]);
   const itemDescription = gameState?.itemDescription || gameState?.emoteDescription;
   const itemPreviewUrl = gameState?.itemPreviewUrl || gameState?.emotePreviewUrl;
   const stats = gameState?.stats;
@@ -188,20 +195,20 @@ export const UnlockView = () => {
           style={shakeCard ? { animation: "shake 0.4s ease-in-out" } : undefined}
         >
           {/* Item preview */}
-          {isAccessory && accessoryPreviewUrls && accessoryPreviewUrls.length > 0 ? (
+          {isAccessory && selectedAccessories.length > 0 ? (
             <div className="flex flex-wrap gap-3 justify-center">
-              {accessoryPreviewUrls.map((url, i) => (
-                <div key={i} className="text-center">
+              {selectedAccessories.map((acc) => (
+                <div key={acc.id} className="text-center">
                   <div className="treasure-frame">
                     <div className="treasure-frame-inner">
                       <img
-                        src={url || defaultIcon}
-                        alt={accessoryNames?.[i] || "Accessory"}
+                        src={acc.previewUrl || defaultIcon}
+                        alt={acc.name}
                         className="w-16 h-16 object-contain"
                       />
                     </div>
                   </div>
-                  {accessoryNames?.[i] && <p className="text-xs mt-2 font-medium text-ink-soft">{accessoryNames[i]}</p>}
+                  <p className="text-xs mt-2 font-medium text-ink-soft">{acc.name}</p>
                 </div>
               ))}
             </div>
@@ -336,7 +343,7 @@ export const UnlockView = () => {
 
             <p className="text-sm text-ink-soft max-w-xs mx-auto leading-relaxed">
               {isAccessory
-                ? `You've unlocked ${accessoryNames?.length || 1} new accessor${(accessoryNames?.length || 1) === 1 ? "y" : "ies"}! Customize your avatar to use them. You may need to reload the page to check out your new accessories.`
+                ? `You've unlocked ${selectedAccessories.length || 1} new accessor${(selectedAccessories.length || 1) === 1 ? "y" : "ies"}! Customize your avatar to use them. You may need to reload the page to check out your new accessories.`
                 : "You've unlocked this emote. Click on your avatar to use it!"}
             </p>
           </div>

--- a/client/src/context/types.ts
+++ b/client/src/context/types.ts
@@ -35,6 +35,13 @@ export type ActionType = {
 
 export type QuestionType = "text" | "open_text" | "multiple_choice" | "all_that_apply";
 
+export type EcosystemAccessory = {
+  id: string;
+  name: string;
+  previewUrl: string;
+  category?: string;
+};
+
 export type GameStateType = {
   // New generic fields
   unlockType?: "emote" | "accessory";
@@ -47,8 +54,7 @@ export type GameStateType = {
   // Accessory multi-select fields
   packId?: string;
   accessoryIds?: string[];
-  accessoryNames?: string[];
-  accessoryPreviewUrls?: string[];
+  ecosystemAccessories?: EcosystemAccessory[];
 
   // Legacy fields (for backwards compatibility)
   emoteId?: string;

--- a/server/controllers/handleGetGameState.ts
+++ b/server/controllers/handleGetGameState.ts
@@ -34,17 +34,21 @@ export const handleGetGameState = async (req: Request, res: Response) => {
       },
     );
 
-    // Resolve accessory display names from inventory cache
-    let accessoryNames = dataObject.accessoryNames;
+    // Resolve accessory details from inventory cache
+    let ecosystemAccessories: { id: string; name: string; previewUrl: string; category?: string }[] = [];
     if (unlockType === "accessory" && dataObject.accessoryIds?.length) {
       try {
         const allItems = await getCachedInventoryItems({ credentials });
-        accessoryNames = dataObject.accessoryIds.map((id: string) => {
-          const item = allItems.find((i: any) => i.id === id);
-          return item?.metadata?.displayName || item?.name || "Accessory";
-        });
+        ecosystemAccessories = allItems
+          .filter((i: any) => i.type === "ACCESSORY")
+          .map((i: any) => ({
+            id: i.id,
+            name: i.metadata?.displayName || i.name || "Accessory",
+            previewUrl: i.image_path || "/default-accessory-icon.svg",
+            category: i.metadata?.category || "",
+          }));
       } catch {
-        // Fall back to persisted names if cache fetch fails
+        // Fall back to empty array if cache fetch fails
       }
     }
 
@@ -54,7 +58,7 @@ export const handleGetGameState = async (req: Request, res: Response) => {
     return res.json({
       unlockData: {
         ...dataObject,
-        accessoryNames,
+        ecosystemAccessories,
         // New fields (always present)
         unlockType,
         itemId,

--- a/server/controllers/handleUnlockConfig.ts
+++ b/server/controllers/handleUnlockConfig.ts
@@ -94,8 +94,6 @@ export const handleUnlockConfig = async (req: Request, res: Response) => {
         unlockType: "accessory",
         packId: selectedPack?.id || "",
         accessoryIds: selectedAccessories.map((a: any) => a.id),
-        accessoryNames: selectedAccessories.map((a: any) => a.name),
-        accessoryPreviewUrls: selectedAccessories.map((a: any) => a.previewUrl || "/default-accessory-icon.svg"),
         itemName: selectedPack?.name || "Accessories",
         itemDescription: itemDescription || "",
         itemPreviewUrl,

--- a/server/types/DroppedAssetInterface.ts
+++ b/server/types/DroppedAssetInterface.ts
@@ -13,8 +13,6 @@ export interface IDroppedAsset extends DroppedAsset {
     itemPreviewUrl?: string;
     itemDescription?: string;
     accessoryIds?: string[];
-    accessoryNames?: string[];
-    accessoryPreviewUrls?: string[];
     packId?: string;
     correctAnswers?: string[] | number[];
     stats: {


### PR DESCRIPTION
Remove accessoryNames and accessoryPreviewUrls arrays that relied on fragile index-based correlation. Server now sends ecosystemAccessories (all ACCESSORY inventory items) and client resolves details by matching accessoryIds against the list.